### PR TITLE
ios pod의 unityAds 4.0버전과 충돌되는 이슈로 3.7.5 버전으로 고정

### DIFF
--- a/react-native-unity-ads.podspec
+++ b/react-native-unity-ads.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   
 
   s.dependency "React"
-  s.dependency "UnityAds"
+  s.dependency "UnityAds", "~> 3.7.5"
 
 end


### PR DESCRIPTION
pod install시에 UnityAds 4.0가 다운로드됩니다.
작성한 코드는 3버전에 맞춰져있기 때문에 변경이 필요합니다.